### PR TITLE
Make installed system use kernel from the ISO

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Next, mount the root filesystem and the EFI partition. (By default the EFI parti
 Finally, run `nixos-install`. Note that this repository is symlinked at `/x1e-nixos-config` for convenience:
 
 ```console
-# nixos-install --root /mnt --no-root-password --flake $(readlink /x1e-nixos-config)#system
+# nixos-install --root /mnt --no-channel-copy --no-root-password --flake $(readlink /x1e-nixos-config)#system
 ```
 
 Note that this could also take over an hour and more than 50% of the battery to compile and install everything, you probably want to have the charger plugged in. The laptop will also get quite hot, be careful with touching it near the hinge.

--- a/README.md
+++ b/README.md
@@ -92,8 +92,6 @@ Finally, run `nixos-install`. Note that this repository is symlinked at `/x1e-ni
 # nixos-install --root /mnt --no-channel-copy --no-root-password --flake $(readlink /x1e-nixos-config)#system
 ```
 
-Note that this could also take over an hour and more than 50% of the battery to compile and install everything, you probably want to have the charger plugged in. The laptop will also get quite hot, be careful with touching it near the hinge.
-
 Now you should have NixOS installed, but you won't be able to boot it yet, you still have to modify the EFI boot configuration.
 
 Reboot into the ISO again, but now select the "EFI Shell" option. For some reason the shell is tiny and appears in the bottom right corner, and the keyboard input is very slow, but you only need to enter a few commands. (You can often use tab completion to reduce the amount of typing necessary.)

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ Note that this could also take over an hour and more than 50% of the battery to 
 
 Now you should have NixOS installed, but you won't be able to boot it yet, you still have to modify the EFI boot configuration.
 
-Reboot into the ISO again, but now select the "EFI Shell" option. For some reason the shell is tiny and appears in the bottom right corner, and the keyboard input is very slow, but you only need to enter a few commands.
+Reboot into the ISO again, but now select the "EFI Shell" option. For some reason the shell is tiny and appears in the bottom right corner, and the keyboard input is very slow, but you only need to enter a few commands. (You can often use tab completion to reduce the amount of typing necessary.)
 
-Run `map -r -b` to reset the filesystem mappings and list them. Look for a `FS*` entry with a path like `PcieRoot(*)/.../NVME(...)/HD(N, ...)` where `N` is the partition number. For me it was `FS4`, so I will use it as an example. Switch to this partition, and verify that it is the right one:
+Run `map -r -b` to reset the filesystem mappings and list them. Look for a `FS*` entry with a path like `PcieRoot(*)/.../NVMe(...)/HD(0x1, ...)`. For me it was `FS4`, so I will use it as an example. Switch to this partition, and verify that it is the right one:
 
 ```console
 Shell> FS4:

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
 
       overlays = [
         (final: prev: {
+          x1e80100-linux = final.callPackage ./packages/x1e80100-linux.nix { };
           x1e80100-lenovo-yoga-slim7x-firmware = final.callPackage ./packages/x1e80100-lenovo-yoga-slim7x-firmware.nix { };
           x1e80100-lenovo-yoga-slim7x-firmware-json = final.callPackage ./packages/x1e80100-lenovo-yoga-slim7x-firmware-json.nix { };
           libqrtr = final.callPackage ./packages/libqrtr.nix { };

--- a/modules/x1e80100.nix
+++ b/modules/x1e80100.nix
@@ -121,42 +121,5 @@ in
     pkgs.x1e80100-lenovo-yoga-slim7x-firmware-json
   ];
 
-  boot.kernelPackages = pkgs.linuxPackagesFor (pkgs.buildLinux {
-    src = pkgs.fetchFromGitHub {
-      owner = "jhovold";
-      repo = "linux";
-      rev = "e92057c615fec749fefcca4ab28ee5c425e3691b";
-      hash = "sha256-7RYZNYlDY2+ileDQAMvsrvhBgUelx4hsqGlU9uRyJrw=";
-    };
-    version = "6.11.0-rc1";
-    defconfig = "johan_defconfig";
-
-    structuredExtraConfig = with lib.kernel; {
-      MAGIC_SYSRQ = yes;
-    };
-
-    kernelPatches = [
-      {
-        name = "driver core: Set deferred probe timeout to 0 if modules are disabled";
-        patch = pkgs.fetchpatch {
-          url = "https://github.com/linux-surface/kernel/commit/fd9dc26bac9b2ca2331f6ca35c9180efcec82aed.patch";
-          hash = "sha256-xMM5ibO9BcdhZ7HJbu22KVXs1Prg9+jqtx7jCYA7f7E=";
-        };
-      }
-      {
-        name = "driver core: Add fw_devlink.timeout param to stop waiting for devlinks ";
-        patch = pkgs.fetchpatch {
-          url = "https://github.com/linux-surface/kernel/commit/431363f94cc23fc3a923cc73758b619a657b75f9.patch";
-          hash = "sha256-9TXoOzmt0OpWHVGa0iaNXrBFvWWTuWFjLwU74cvOED0=";
-        };
-      }
-      {
-        name = "driver core: Disable driver deferred probe timeout by default";
-        patch = pkgs.fetchpatch {
-          url = "https://github.com/linux-surface/kernel/commit/caa65dd351ed735b33371f26fbbd02d37a1d2098.patch";
-          hash = "sha256-yGZ1hn/1nj0M4wn4mNwYzPkaV46JDaU2uZvAQvQ5lQY=";
-        };
-      }
-    ];
-  });
+  boot.kernelPackages = pkgs.x1e80100-linux;
 }

--- a/packages/x1e80100-linux.nix
+++ b/packages/x1e80100-linux.nix
@@ -1,0 +1,40 @@
+{ lib, fetchFromGitHub, buildLinux, linuxPackagesFor, fetchpatch, ... }:
+
+linuxPackagesFor (buildLinux {
+  src = fetchFromGitHub {
+    owner = "jhovold";
+    repo = "linux";
+    rev = "e92057c615fec749fefcca4ab28ee5c425e3691b";
+    hash = "sha256-7RYZNYlDY2+ileDQAMvsrvhBgUelx4hsqGlU9uRyJrw=";
+  };
+  version = "6.11.0-rc1";
+  defconfig = "johan_defconfig";
+
+  structuredExtraConfig = with lib.kernel; {
+    MAGIC_SYSRQ = yes;
+  };
+
+  kernelPatches = [
+    {
+      name = "driver core: Set deferred probe timeout to 0 if modules are disabled";
+      patch = fetchpatch {
+        url = "https://github.com/linux-surface/kernel/commit/fd9dc26bac9b2ca2331f6ca35c9180efcec82aed.patch";
+        hash = "sha256-xMM5ibO9BcdhZ7HJbu22KVXs1Prg9+jqtx7jCYA7f7E=";
+      };
+    }
+    {
+      name = "driver core: Add fw_devlink.timeout param to stop waiting for devlinks ";
+      patch = fetchpatch {
+        url = "https://github.com/linux-surface/kernel/commit/431363f94cc23fc3a923cc73758b619a657b75f9.patch";
+        hash = "sha256-9TXoOzmt0OpWHVGa0iaNXrBFvWWTuWFjLwU74cvOED0=";
+      };
+    }
+    {
+      name = "driver core: Disable driver deferred probe timeout by default";
+      patch = fetchpatch {
+        url = "https://github.com/linux-surface/kernel/commit/caa65dd351ed735b33371f26fbbd02d37a1d2098.patch";
+        hash = "sha256-yGZ1hn/1nj0M4wn4mNwYzPkaV46JDaU2uZvAQvQ5lQY=";
+      };
+    }
+  ];
+})


### PR DESCRIPTION
This massively reduces install time, as now compiling the kernel on the device is not required.