### PR TITLE
Update kernel to 6.11-rc6

### DIFF
--- a/modules/x1e80100.nix
+++ b/modules/x1e80100.nix
@@ -28,8 +28,6 @@
     "panel_samsung_atna33xc20"
   ];
 
-  boot.blacklistedKernelModules = [ "qcom_edac" ];
-
   boot.kernelParams = [
     "pd_ignore_unused"
     "clk_ignore_unused"

--- a/packages/x1e80100-linux.nix
+++ b/packages/x1e80100-linux.nix
@@ -4,10 +4,10 @@ linuxPackagesFor (buildLinux {
   src = fetchFromGitHub {
     owner = "jhovold";
     repo = "linux";
-    rev = "wip/x1e80100-6.11-rc6";
-    hash = "sha256-5jpYa6Dkjg18iYFLdDNAJEYQEe/Bcqjkt0fRuyPgRz0=";
+    rev = "wip/x1e80100-6.11-rc7";
+    hash = "sha256-p5DcTD5Vt1ME3jb9d+QPBjoOpbpV371sucK7bb+V3JA=";
   };
-  version = "6.11.0-rc6";
+  version = "6.11.0-rc7";
   defconfig = "johan_defconfig";
 
   structuredExtraConfig = with lib.kernel; {


### PR DESCRIPTION
The qcom_edac module does not need to be blacklisted anymore as a fix for it is now included in jhovold's wip/x1e80100-6.11-rc7 branch.

The ISO should be reproducible and have the following SHA256 hash: 0cfce12defdebf5277a76b0a5c5f27cd642a76c23de30eb08e0e51bb9a047572