### PR TITLE
Update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725312155,
-        "narHash": "sha256-2OOXFGJp2J7gFR53a9cLPZwW7WBJ7F/2eed9J8+x2qc=",
+        "lastModified": 1725973939,
+        "narHash": "sha256-h70wJn4Z6c3HpEHJ5wEiVqx+cSOMjneEdcbFQDmnc6Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "48a3af7fc1f8447de658cb5bc056c9488427c1fa",
+        "rev": "0cfa0d860b6ec2c5113909d569e0868062bd9c30",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "48a3af7fc1f8447de658cb5bc056c9488427c1fa",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,6 @@
 {
   inputs = {
-    # Nothing is special about this revision other than me having used it
-    # during experimentation and having all the build results already cached.
-    # Will update it eventually.
-    nixpkgs.url = "github:nixos/nixpkgs?rev=48a3af7fc1f8447de658cb5bc056c9488427c1fa";
+    nixpkgs.url = "github:nixos/nixpkgs";
   };
   outputs = { self, nixpkgs }:
     let
@@ -33,15 +30,6 @@
           x1e80100-lenovo-yoga-slim7x-firmware-json = final.callPackage ./packages/x1e80100-lenovo-yoga-slim7x-firmware-json.nix { };
           libqrtr = final.callPackage ./packages/libqrtr.nix { };
           pd-mapper = final.callPackage ./packages/pd-mapper.nix { };
-
-          linux-firmware = prev.linux-firmware.overrideAttrs (_: {
-            src = final.fetchgit
-              {
-                url = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git";
-                rev = "82318c966fd1af87044299d34611751c76f70927";
-                hash = "sha256-7nl9FCB9aIcjF2DUO4yI4pAigJlfwNYmn7Skw7fwL98=";
-              };
-          });
         })
       ];
 

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# This script can be used to test the installer quickly. To use it, you need
+# the following:
+# - create an EFI partition with the filesystem label "TESTING-EFI"
+# - create a root partition with the partition label "testing-root"
+# To install, connect to Wi-Fi, then run this script as
+# `sudo /x1e-nixos-config/scripts/test-install.sh`.
+
+set -ex
+
+if ! mountpoint /mnt; then
+    yes | mkfs.ext4 -L root /dev/disk/by-partlabel/testing-root
+    mount /dev/disk/by-label/root /mnt
+    mkdir -p /mnt/boot
+    mount /dev/disk/by-label/TESTING-EFI /mnt/boot
+fi
+nixos-install --root /mnt --no-channel-copy --no-root-password --flake $(readlink /x1e-nixos-config)#system


### PR DESCRIPTION
A new linux-firmware release has made it into nixpkgs, so the override
can be removed now.

This update includes a staging branch merge in nixpkgs, so be prepared
for another day of compiling.

The ISO should be reproducible and have the following SHA256 hash:
e6d2f21f9d5770a77cd464c91ba97e3859605695a1303401eb4094f16c6686fe