### PR TITLE
Fix spurious hash mismatches for lore.kernel.org patches

### DIFF
--- a/packages/x1e80100-linux.nix
+++ b/packages/x1e80100-linux.nix
@@ -33,21 +33,21 @@ linuxPackagesFor (buildLinux {
     {
       name = "dt-bindings: platform: Add bindings for Lenovo Yoga Slim 7x EC";
       patch = fetchurl {
-        url = "https://lore.kernel.org/all/20240927185345.3680-1-maccraft123mc@gmail.com/raw";
+        url = "https://lore.kernel.org/linux-devicetree/20240927185345.3680-1-maccraft123mc@gmail.com/raw";
         hash = "sha256-MHbAUR9KMy/DWOfyJBwW7MoM1FK8JmmNEpEvQ6NXJRU=";
       };
     }
     {
       name = "platform: arm64: Add driver for Lenovo Yoga Slim 7x's EC";
       patch = fetchurl {
-        url = "https://lore.kernel.org/all/20240927185345.3680-2-maccraft123mc@gmail.com/raw";
+        url = "https://lore.kernel.org/platform-driver-x86/20240927185345.3680-2-maccraft123mc@gmail.com/raw";
         hash = "sha256-LL88vnk5xvEcC1WVkV+R8aKW9gg43HHC8ZqwaHscfmg=";
       };
     }
     {
       name = "arm64: dts: qcom: Add EC to Lenovo Yoga Slim 7x";
       patch = fetchurl {
-        url = "https://lore.kernel.org/all/20240927185345.3680-3-maccraft123mc@gmail.com/raw";
+        url = "https://lore.kernel.org/linux-arm-msm/20240927185345.3680-3-maccraft123mc@gmail.com/raw";
         hash = "sha256-tnpo07ZPi/3cdiY9h90rf2UgTjr9ZfR1PYRVVQJ2pUQ=";
       };
     }


### PR DESCRIPTION
A user reported the following diff compared to what I downloaded:

```
< X-Mailing-List: linux-arm-msm@vger.kernel.org
< List-Id: <linux-arm-msm.vger.kernel.org>
< List-Subscribe: <mailto:linux-arm-msm+subscribe@vger.kernel.org>
< List-Unsubscribe: <mailto:linux-arm-msm+unsubscribe@vger.kernel.org>
---
> X-Mailing-List: devicetree@vger.kernel.org
> List-Id: <devicetree.vger.kernel.org>
> List-Subscribe: <mailto:devicetree+subscribe@vger.kernel.org>
> List-Unsubscribe: <mailto:devicetree+unsubscribe@vger.kernel.org>
```

Based on this, it seems that lore.kernel.org can get confused about which mailing list an email belongs to. Attempt to fix this by specifying the mailing lits explicitly in the URL.