### PR TITLE
Update linux to 6.13-rc2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731951811,
-        "narHash": "sha256-fSxubVm9MP+uf95rpoLRpgkKoLeeRLr+nktZaSX3K48=",
+        "lastModified": 1733857688,
+        "narHash": "sha256-TFwJq1urIFVEs5HodohMcDlSCaDiP5AyRVQ7ozG2Cpg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4a2fe438081e653fb0556c8fcc036bc003306413",
+        "rev": "b32a0943687d2a5094a6d92f25a4b6e16a76b5b7",
         "type": "github"
       },
       "original": {

--- a/packages/x1e80100-linux.nix
+++ b/packages/x1e80100-linux.nix
@@ -4,10 +4,10 @@ linuxPackagesFor (buildLinux {
   src = fetchFromGitHub {
     owner = "jhovold";
     repo = "linux";
-    rev = "wip/x1e80100-6.12";
-    hash = "sha256-CUt4J7IFS14qD8GiZOuSeJmFdbWOmmyV/iJNcTUVN5g=";
+    rev = "wip/x1e80100-6.13-rc2";
+    hash = "sha256-sCapdt5lYw/zXIPIrJ5hECL9Xqviizerp9dmnx4BJpc=";
   };
-  version = "6.12.0";
+  version = "6.13.0-rc2";
   defconfig = "johan_defconfig";
 
   structuredExtraConfig = with lib.kernel; {
@@ -16,13 +16,6 @@ linuxPackagesFor (buildLinux {
   };
 
   kernelPatches = [
-    {
-      name = "drm/panic: Select ZLIB_DEFLATE for DRM_PANIC_SCREEN_QR_CODE";
-      patch = fetchurl {
-        url = "https://lore.kernel.org/linux-kernel/20241003230734.653717-1-ojeda@kernel.org/raw";
-        hash = "sha256-qZTP9o0Pel9M1Y9f/31SZbOJxeM0j28P94EUXa83m+Q=";
-      };
-    }
     {
       name = "Add Bluetooth support for the Lenovo Yoga Slim 7x";
       patch = fetchpatch {

--- a/packages/x1e80100-linux.nix
+++ b/packages/x1e80100-linux.nix
@@ -17,6 +17,15 @@ linuxPackagesFor (buildLinux {
 
   kernelPatches = [
     {
+      name = ''Revert "arm64: dts: qcom: x1e80100: Add debug uart to Lenovo Yoga Slim 7x"'';
+      patch = fetchpatch {
+        url = "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/patch/?id=4c3d9c134892c4158867075c840b81a5ed28af1f";
+        revert = true;
+        hash = "sha256-6lt0nq0qiV6a+Rnu39aMiesoInxdzHOPd4LmGNUIhOU=";
+      };
+    }
+
+    {
       name = "Add Bluetooth support for the Lenovo Yoga Slim 7x";
       patch = fetchpatch {
         # Bit contrived, to match the output path of the original FOD.


### PR DESCRIPTION
I bisected linux so I found the commit that is causing the systemd messages to not appear, though I am not sure about the root cause. Added a revert for now, and it fixes the issue.

Also this PR does not build currently without this: https://github.com/NixOS/nixpkgs/pull/364044
I might just include it as a nixpkgs patch if that PR does not get attention quickly, we are already patching nixpkgs anyway...