### PR TITLE
Remove usage of `boot.initrd.availableKernelModules = lib.mkForce [`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733932090,
-        "narHash": "sha256-ON2S8T1wDZwsD+mwSERro/U7u+8iH4NVJXyZgc1fnqc=",
+        "lastModified": 1734534227,
+        "narHash": "sha256-K9wYK37OZAuIAxIFLt37gxu16LbuPqwlr6eWixK7xXg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "204afb3d25f51a296b5d4c0ae9d39d5c1e9bdee2",
+        "rev": "2718b24d904ce592c6323ac49398734b01fc6778",
         "type": "github"
       },
       "original": {

--- a/iso.nix
+++ b/iso.nix
@@ -5,6 +5,8 @@
   boot.supportedFilesystems.zfs = lib.mkForce false;
   boot.supportedFilesystems.cifs = lib.mkForce false;
 
+  hardware.enableAllHardware = lib.mkForce false;
+
   # For some reason the adsp booting up messes with USB boot, so disable it.
   boot.blacklistedKernelModules = [ "qcom_q6v5_pas" ];
 

--- a/modules/x1e80100.nix
+++ b/modules/x1e80100.nix
@@ -1,13 +1,9 @@
 { pkgs, lib, ... }:
 
 {
-  boot.initrd.availableKernelModules = lib.mkForce [
-    # Needed by the NixOS iso for booting in general
-    "squashfs"
-    "iso9660"
-    "uas"
-    "overlay"
-
+  boot.initrd.includeDefaultModules = false;
+  boot.initrd.systemd.tpm2.enable = false; # This also pulls in some modules our kernel is not build with.
+  boot.initrd.availableKernelModules = [
     # Definitely needed for USB:
     "usb_storage"
     "phy_qcom_qmp_combo"


### PR DESCRIPTION
Fixes #66

TODO:
- [x] Test module with own config
- [x] Test installer