### PR TITLE
Update kernel to 6.13-rc6

### DIFF
--- a/packages/x1e80100-linux.nix
+++ b/packages/x1e80100-linux.nix
@@ -12,10 +12,10 @@ linuxPackagesFor (buildLinux {
   src = fetchFromGitHub {
     owner = "jhovold";
     repo = "linux";
-    rev = "wip/x1e80100-6.13-rc3";
-    hash = "sha256-7ewKQA8hwqNnwkTEy3yo7EtoD65BeRknjRy5DmN6Xyo=";
+    rev = "wip/x1e80100-6.13-rc6";
+    hash = "sha256-xny3obRX9bPKCT5PbzuprEoH6nBgNDV0gVcVeucV+0M=";
   };
-  version = "6.13.0-rc3";
+  version = "6.13.0-rc6";
   defconfig = "johan_defconfig";
 
   structuredExtraConfig = with lib.kernel; {


### PR DESCRIPTION
The ISO should be reproducible and have the following SHA256 hash: 822f4904c9ea2ff93361d0e035997d1318ca8064ebfc6d91ffba008c9d62a165