### PR TITLE
Enable KVM support in the kernel

### DIFF
--- a/packages/x1e80100-linux.nix
+++ b/packages/x1e80100-linux.nix
@@ -19,6 +19,8 @@ linuxPackagesFor (buildLinux {
   defconfig = "johan_defconfig";
 
   structuredExtraConfig = with lib.kernel; {
+    VIRTUALIZATION = yes;
+    KVM = yes;
     MAGIC_SYSRQ = yes;
     EC_LENOVO_YOGA_SLIM7X = module;
   };


### PR DESCRIPTION
Note that this for this to actually be usable the kernel needs to be launched in EL2. I am still working on integrating that in another feature branch, but I already want to merge this so I don't have to recompile the kernel when working on that.