### PR TITLE
Get treefmt-nix using a FOD instead of as a flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,28 +17,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1733761991,
-        "narHash": "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,14 +1,11 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs";
-    treefmt-nix.url = "github:numtide/treefmt-nix";
-    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
   };
   outputs =
     {
       self,
       nixpkgs,
-      treefmt-nix,
     }:
     let
       # Modify this if you are building on something other than x86_64-linux.
@@ -86,7 +83,18 @@
         ];
         treefmtEval = eachSystem (
           system:
-          (treefmt-nix.lib.evalModule nixpkgs.legacyPackages.${system} {
+          let
+            pkgs = nixpkgs.legacyPackages.${system};
+            treefmt-nix = import (
+              pkgs.fetchFromGitHub {
+                owner = "numtide";
+                repo = "treefmt-nix";
+                rev = "0ce9d149d99bc383d1f2d85f31f6ebd146e46085";
+                hash = "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=";
+              }
+            );
+          in
+          (treefmt-nix.evalModule pkgs {
             programs.nixfmt.enable = true;
             settings.on-unmatched = "info";
           })


### PR DESCRIPTION
Since flake inputs are propagated to downstream users of our flakes, having treefmt-nix in there is somewhat inconvenient, since it's only used for development.

You can verify based on the diff that the rev and hash of the treefmt-nix version used stayed the same.

Fixes #65 