### PR TITLE
Enable mdformat to format markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,33 +11,33 @@ Note that I only have the Lenovo Yoga Slim 7x, so the repo will be focused aroun
 
 ## Feature Matrix
 
-| Feature                 | Status | Notes                                                                                                        |
-| ----------------------- | -----: | ------------------------------------------------------------------------------------------------------------ |
-| Battery Charging        |     ✅ |                                                                                                              |
-| Battery Indicator       |     ✅ | Not working in EL2. (More info [below](#running-virtual-machines-with-kvm).)                                 |
-| Bluetooth               |     ✅ |                                                                                                              |
-| Camera                  |     ❌ |                                                                                                              |
-| Display                 |     ✅ |                                                                                                              |
-| GPU Acceleration        |     ✅ |                                                                                                              |
-| Hardware Video Decoding |     ❌ |                                                                                                              |
-| Hibernate               |     ❔ |                                                                                                              |
-| Keyboard                |     ✅ |                                                                                                              |
-| Lid switch              |     ✅ |                                                                                                              |
-| Microphone              |     ❌ |                                                                                                              |
-| NVMe                    |     ✅ |                                                                                                              |
-| Power Profiles          |     ❌ |                                                                                                              |
-| RTC                     |     ✅ |                                                                                                              |
-| Speakers                |     ❌ |                                                                                                              |
-| Suspend                 |     🟨 | Spurious wakeups can happen. Battery consumption still high (approx. 3.8%/hour).                             |
-| Thermal throttling      |     ❌ |                                                                                                              |
-| Touchpad                |     ✅ |                                                                                                              |
-| Touchscreen             |     ✅ |                                                                                                              |
-| TPM                     |     ❌ |                                                                                                              |
-| USB-C 4                 |     ❔ |                                                                                                              |
-| USB-C Booting           |     ✅ |                                                                                                              |
-| USB-C DP Alt Mode       |     🟨 | Mostly working. Right side port broken for some reason.                                                      |
-| USB-C PCIe              |     ❌ |                                                                                                              |
-| Wi-Fi                   |     ✅ |                                                                                                              |
+| Feature                 | Status | Notes                                                                            |
+| ----------------------- | -----: | -------------------------------------------------------------------------------- |
+| Battery Charging        |     ✅ |                                                                                  |
+| Battery Indicator       |     ✅ | Not working in EL2. (More info [below](#running-virtual-machines-with-kvm).)     |
+| Bluetooth               |     ✅ |                                                                                  |
+| Camera                  |     ❌ |                                                                                  |
+| Display                 |     ✅ |                                                                                  |
+| GPU Acceleration        |     ✅ |                                                                                  |
+| Hardware Video Decoding |     ❌ |                                                                                  |
+| Hibernate               |     ❔ |                                                                                  |
+| Keyboard                |     ✅ |                                                                                  |
+| Lid switch              |     ✅ |                                                                                  |
+| Microphone              |     ❌ |                                                                                  |
+| NVMe                    |     ✅ |                                                                                  |
+| Power Profiles          |     ❌ |                                                                                  |
+| RTC                     |     ✅ |                                                                                  |
+| Speakers                |     ❌ |                                                                                  |
+| Suspend                 |     🟨 | Spurious wakeups can happen. Battery consumption still high (approx. 3.8%/hour). |
+| Thermal throttling      |     ❌ |                                                                                  |
+| Touchpad                |     ✅ |                                                                                  |
+| Touchscreen             |     ✅ |                                                                                  |
+| TPM                     |     ❌ |                                                                                  |
+| USB-C 4                 |     ❔ |                                                                                  |
+| USB-C Booting           |     ✅ |                                                                                  |
+| USB-C DP Alt Mode       |     🟨 | Mostly working. Right side port broken for some reason.                          |
+| USB-C PCIe              |     ❌ |                                                                                  |
+| Wi-Fi                   |     ✅ |                                                                                  |
 
 Some things may be working and have drivers, but are not yet included here.
 
@@ -52,7 +52,7 @@ Note that the device tree in the releases is hardcoded for the Lenovo Yoga Slim 
 There are two main ways to build the ISO:
 
 1. The default setting is to cross-compile from x86_64 to aarch64. This takes several hours as all packages are compiled from scratch.
-2. Using WSL on the Lenovo Yoga Slim 7x to build using Nix. This generally takes 25 minutes as only the kernel is compiled from scratch.
+1. Using WSL on the Lenovo Yoga Slim 7x to build using Nix. This generally takes 25 minutes as only the kernel is compiled from scratch.
 
 If your build system is not `x86_64-linux` you have to modify `buildSystem` in `flake.nix`, e.g. to `aarch64-linux` if building in WSL.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,8 +1,8 @@
 ## How to upload a new release to GitHub
 
 1. Build the ISO.
-2. On GitHub on the project page, click "Releases" in the right column, and then press the "Draft a new release" button in the top row.
-3. First, click the "Choose a tag" dropdown, type in "v0.0.X" where X should be one larger than the previous version, and select the "Create a new tag: v0.0.X" option.
-4. In the "Release title" field, type the same version number.
-5. Click the "Attach binaries by dropping them here or selecting them." button, and upload the ISO file.
-6. Finally, click the "Publish release" button at the bottom.
+1. On GitHub on the project page, click "Releases" in the right column, and then press the "Draft a new release" button in the top row.
+1. First, click the "Choose a tag" dropdown, type in "v0.0.X" where X should be one larger than the previous version, and select the "Create a new tag: v0.0.X" option.
+1. In the "Release title" field, type the same version number.
+1. Click the "Attach binaries by dropping them here or selecting them." button, and upload the ISO file.
+1. Finally, click the "Publish release" button at the bottom.

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,10 @@
           (treefmt-nix.evalModule pkgs {
             programs.nixfmt.enable = true;
             settings.on-unmatched = "info";
+            programs.mdformat = {
+              enable = true;
+              package = pkgs.mdformat.withPlugins (p: [ p.mdformat-gfm ]);
+            };
           })
         );
       in


### PR DESCRIPTION
You might notice that now the lists have all items numbered as "1". It turns out that this is actually a feature and there is an option to disable it. I think it is meant to reduce diff noise when adding/removing items from lists... which I guess makes sense? Just takes a bit of getting used to.