### PR TITLE
Improved multi-device support

### DIFF
--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -23,7 +23,7 @@ sed -i s/SYSTEM_DRV/TESTING-EFI/ "$flake"/examples/flake-based-config/configurat
 # Query the ISO derivation, check its build system
 if [ -f /run/booted-system/build-system ] && [ "$(< /run/booted-system/build-system)" = "x86_64-linux" ]; then
     # Patch the config to use the cross-compiled kernel from the ISO
-    sed -i '/flake-based-config/a ({ lib, ... }: { boot.kernelPackages = lib.mkForce self.nixosConfigurationsForBuildSystem.x86_64-linux.iso.config.boot.kernelPackages; })' "$flake"/flake.nix
+    sed -i '/flake-based-config/a ({ lib, ... }: { boot.kernelPackages = lib.mkForce self.nixosConfigurationsForBuildSystem.x86_64-linux.lenovo-yoga-slim7x-iso.config.boot.kernelPackages; })' "$flake"/flake.nix
 fi
 
 nixos-install --root /mnt --no-channel-copy --no-root-password --flake "${flake}#system"


### PR DESCRIPTION
- **Expose overlay**: exposes the package overlay as `overlays.x1e` and `overlays.default`
- **Expose per-device ISOs**: adds packages for each device ending with `-iso` for an ISO for that device

The old `iso` package is now an alias for `lenovo-yoga-slim7x-iso`.