### PR TITLE
FIXED: Long boot and switch times caused by tpm

### DIFF
--- a/examples/flake-based-config/configuration.nix
+++ b/examples/flake-based-config/configuration.nix
@@ -16,7 +16,7 @@
     emergencyAccess = true;
   };
   
-  # Remove this if you are using tpm
+  # Remove this if you are using tpm (Trusted Platform Module)
   systemd.tpm2.enable = false;
 
   hardware.enableRedistributableFirmware = true;


### PR DESCRIPTION
Well using my the example nixos flake as a base I kept on seeing  "A start job is running for /dev/tpmrm0 (13s / 1min 30s)" and having to wait for it to time out for it to finish booting. After fixing it in my config I relisted it was also causing my nixos-rebuild switch to take way longer than needed. So I think it should be disabled by default or at least a comment away in the example.  