### PR TITLE
Fix dark lcd panel at LUKS prompt- Add t14s HDMI bridge chain modules to initrd

### DIFF
--- a/modules/x1e80100.nix
+++ b/modules/x1e80100.nix
@@ -77,6 +77,18 @@ in
               # Needed for USB
               "phy_nxp_ptn3222"
               "phy_qcom_qmp_usb"
+
+              # Kernel 7.1.x adds the t14s HDMI port to the device tree:
+              # mdss_dp2 (ae9a000) -> aux_bridge -> rtd2171 (simple_bridge) ->
+              # hdmi-connector (display_connector). msm's component bind waits
+              # for the complete bridge chain of every DP controller, so
+              # without these the internal panel stays dark for all of stage 1
+              # (e.g. while typing the LUKS passphrase).
+              "simple_bridge"
+              "display_connector"
+              "mux_gpio"
+              "reset_gpio"
+              "gpio_shared_proxy"
             ])
           ];
 


### PR DESCRIPTION
Tested on my t14s. change made by Claude. Feel free to copy this and edit as you want, or I can make changes if needed.

Since kernel 7.1.x the device tree describes the t14s HDMI port:
mdss_dp2 (ae9a000) -> aux_bridge -> rtd2171 (simple_bridge) ->
hdmi-connector (display_connector). msm's component bind waits for the
complete bridge chain of every DP controller, so with these drivers
missing from the initrd msm never initializes during stage 1 and the
internal panel stays dark, e.g. while typing the LUKS passphrase
(journal shows 'aux_bridge.aux_bridge.2: deferred probe pending:
failed to acquire drm_bridge'). The display only comes back once
stage 2 udev coldplug loads the missing modules.