### PR TITLE
Add ASUS Zenbook A14 UX3407QA (OLED) support

### DIFF
--- a/devices.nix
+++ b/devices.nix
@@ -7,4 +7,8 @@
     displayName = "Lenovo ThinkPad T14s Gen 6";
     deviceTreeName = "qcom/x1e78100-lenovo-thinkpad-t14s.dtb";
   };
+  asus-zenbook-a14 = {
+    displayName = "ASUS Zenbook A14 (UX3407QA)";
+    deviceTreeName = "qcom/x1p42100-asus-zenbook-a14.dtb";
+  };
 }

--- a/modules/x1e80100.nix
+++ b/modules/x1e80100.nix
@@ -90,6 +90,22 @@ in
               "reset_gpio"
               "gpio_shared_proxy"
             ])
+
+            (lib.mkIf cfg.asus-zenbook-a14.enable [
+              # Needed for UX3407QA OLED display
+              "panel_samsung_atna33xc20"
+              "gpucc_x1p42100"
+
+              # Needed for USB
+              "phy_nxp_ptn3222"
+
+              # HDMI stuff, see above
+              "simple_bridge"
+              "display_connector"
+              "mux_gpio"
+              "reset_gpio"
+              "gpio_shared_proxy"
+            ])
           ];
 
           boot.kernelParams = lib.mkMerge [
@@ -114,11 +130,41 @@ in
             (lib.mkIf cfg.lenovo-thinkpad-t14s.enable [
               "mem=31G"
             ])
+
+            (lib.mkIf cfg.asus-zenbook-a14.enable [
+              "console=tty1"
+              "cma=128M"
+              "efi=noruntime"
+              "arm64.nopauth"
+            ])
           ];
 
           hardware.deviceTree.enable = true;
 
           boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
+
+          boot.extraModulePackages =
+            let
+              asus-zenbook-a14-ec =
+                config.boot.kernelPackages.callPackage ../packages/asus-zenbook-a14-ec.nix
+                  { };
+            in
+            lib.mkMerge [
+              [ ]
+              (lib.mkIf cfg.asus-zenbook-a14.enable [
+                # This currently depends on ACPI=y for an architectural reason
+                asus-zenbook-a14-ec
+              ])
+            ];
+
+          boot.kernelModules = lib.mkMerge [
+            [ ]
+            (lib.mkIf cfg.asus-zenbook-a14.enable [
+              # Provided by asus-zenbook-a14-ec
+              "asus-zenbook-a14-ec" # Does not autoload
+              "hid-asus-ec" # Does seem to autoload, but just to be safe
+            ])
+          ];
 
           boot.initrd.extraFirmwarePaths = lib.mkMerge [
             (lib.mkIf cfg.lenovo-thinkpad-t14s.enable [
@@ -136,6 +182,24 @@ in
               "qcom/x1e80100/LENOVO/21N1/cdsp_dtbs.elf"
               "qcom/x1e80100/adsp.mbn"
               "qcom/x1e80100/adsp_dtb.mbn"
+            ])
+            (lib.mkIf cfg.asus-zenbook-a14.enable [
+              # Some of these are not in linux-firmware and need to be packaged separately
+              # Will still boot if those are missing, BAT reporting and WLAN will be dead though
+              "qcom/gen71500_gmu.bin"
+              "qcom/gen71500_sqe.fw"
+              "qcom/x1p42100/gen71500_zap.mbn"
+              "qcom/x1p42100/ASUSTeK/zenbook-a14/adsp_dtbs.elf"
+              "qcom/x1p42100/ASUSTeK/zenbook-a14/adspr.jsn"
+              "qcom/x1p42100/ASUSTeK/zenbook-a14/adsps.jsn"
+              "qcom/x1p42100/ASUSTeK/zenbook-a14/adspua.jsn"
+              "qcom/x1p42100/ASUSTeK/zenbook-a14/battmgr.jsn"
+              "qcom/x1p42100/ASUSTeK/zenbook-a14/cdsp_dtbs.elf"
+              "qcom/x1p42100/ASUSTeK/zenbook-a14/cdspr.jsn"
+              "qcom/x1p42100/ASUSTeK/zenbook-a14/qcadsp8380.mbn"
+              "qcom/x1p42100/ASUSTeK/zenbook-a14/qccdsp8380.mbn"
+              "qcom/x1p42100/ASUSTeK/zenbook-a14/qcdxmsuc8380.mbn"
+              "qcom/x1p42100/ASUSTeK/zenbook-a14/qcdxkmsucpurwa.mbn"
             ])
           ];
 

--- a/modules/x1e80100.nix
+++ b/modules/x1e80100.nix
@@ -130,13 +130,6 @@ in
             (lib.mkIf cfg.lenovo-thinkpad-t14s.enable [
               "mem=31G"
             ])
-
-            (lib.mkIf cfg.asus-zenbook-a14.enable [
-              "console=tty1"
-              "cma=128M"
-              "efi=noruntime"
-              "arm64.nopauth"
-            ])
           ];
 
           hardware.deviceTree.enable = true;

--- a/packages/asus-zenbook-a14-ec.nix
+++ b/packages/asus-zenbook-a14-ec.nix
@@ -1,0 +1,43 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  kernel,
+  kmod,
+}:
+let
+  kdir = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+in
+
+stdenv.mkDerivation rec {
+  pname = "asus-zenbook-a14-ec";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "Sombre-Osmoze";
+    repo = "asus-zenbook-a14-ec";
+    rev = "387cbf82498c85c3a0c44a09bfe853ba43fe5d6c";
+    hash = "sha256-BGQ8gz2MiLVU9M59Wnc5kahreyG3lIDH99wD3q5i+H0=";
+  };
+
+  hardeningDisable = [
+    "pic"
+    "format"
+  ];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  installPhase = ''
+    make -C ${kdir} M=$(pwd) INSTALL_MOD_PATH=$out modules_install
+  '';
+  makeFlags = [
+    "KDIR=${kdir}"
+  ];
+
+  meta = {
+    description = "A kernel module to handle ASUS Zenbook A14 (UX3407QA/RA) EC";
+    homepage = "https://github.com/Sombre-Osmoze/asus-zenbook-a14-ec";
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.makefu ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/packages/overlay.nix
+++ b/packages/overlay.nix
@@ -2,4 +2,5 @@ final: prev: {
   x1e80100-linux = final.callPackage ./x1e80100-linux.nix { };
   slbounce = final.callPackage ./slbounce.nix { };
   qebspil = final.callPackage ./qebspil.nix { };
+  asus-zenbook-a14-ec = final.callPackage ./asus-zenbook-a14-ec.nix { };
 }


### PR DESCRIPTION
This one is x1p42100 (purwa), and this platform does not have all the needed blobs in linux-firmware as of time of writing.

I debated with myself for a bit about how this should be approached, and decided that final devices should have it packaged on their own. Alternatives being:
- Having a stub package here with sources pointing to an empty dir in this repo, which the user will populate manually after cloning the repo. Simple, but very jank imo
- Having a stub package here with configurable sources. Seems a little less jank, but I am not that versed in nix to do that (can you even pass config to overlays?)
- Pulling blobs from Windows on each rebuild. Cannot be built outside an existing device, and somewhat complex
- Pulling blobs from Windows on each boot. Seems to mess with NixOS a bit too much, and droid-juicer needs patching for this to work, too complex

 If there are any other ideas, would be glad to implement. Either way, it builds and boots if these blobs are not present, but BAT charge reporting, GPU accel and WLAN will be dead, among some other minor things
 
 There is also an LCD variant on this device, that probably needs other kernel modules and a different device tree, not sure if they are required in initrd. That will boot with this config, but backlight cannot be managed there
 
 Also EC driver included needs a [patched kernel](https://github.com/Sombre-Osmoze/asus-zenbook-a14-ec/tree/master#kernel-patch). "asus-zenbook-a14-ec" will not load, but "hid-asus-ec" (provided in the same repo and package) will and will provide its functionalities in full. Decided to include both in boot.kernelModules, that does not impact functionality in worst case
 
 This does not cover the x1e80100 (RA instead of QA) and x2e variants that also go by zenbook a14 ux3407, so perhaps this needs a rename in devices.nix